### PR TITLE
[G2M] Auto main|master branch detection

### DIFF
--- a/.depcheckrc
+++ b/.depcheckrc
@@ -1,0 +1,2 @@
+ignore-dirs: ["node_modules"]
+ignores: ["jest", "eslint", "eslint-*"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   dogfood:
     runs-on: ubuntu-latest
+    if: contains(github.event_name, 'pull_request')
     strategy:
       matrix:
         node-version: [12.x, 14.x, 15.x, 16.x]
@@ -102,7 +103,7 @@ jobs:
   release:
     name: Trigger a release
     runs-on: ubuntu-latest
-    needs: [dogfood, lint, depcheck]
+    needs: [lint, depcheck]
     if: contains(github.event_name, 'push')
     steps:
       - name: checkout
@@ -112,7 +113,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - run: npm i
       - name: Create tag
         if: ${{ success() }}

--- a/.github/workflows/npm-alpha.yml
+++ b/.github/workflows/npm-alpha.yml
@@ -13,19 +13,19 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
-          registry-url: https://registry.npmjs.org/
+          node-version: 14.x
+          registry-url: https://npm.pkg.github.com/
           scope: '@eqworks'
       - run: npm i # only install once
       - run: npm publish --access public --tag alpha
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
-          registry-url: https://npm.pkg.github.com/
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org/
           scope: '@eqworks'
       - run: npm publish --access public --tag alpha
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -14,22 +14,22 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
-          registry-url: https://registry.npmjs.org/
+          node-version: 14.x
+          registry-url: https://npm.pkg.github.com/
           scope: '@eqworks'
       - run: npm i # only install once
       - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 12.x
-          registry-url: https://npm.pkg.github.com/
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org/
           scope: '@eqworks'
       - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.CD_NPM_TOKEN_PUBLISH }}
 
       - name: Generate tag associated release changelog
         if: ${{ success() }}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A CLI to gatekeep commit messages that do not conform to conventions.
 
 ## Installation
 
+If you have `npx` available, you can directly use it without explicit installation:
+
+```shell
+% npx @eqworks/commit-watch --help
+```
+
+Otherwise, or when explicitly local installation is needed:
+
 ```shell
 % npm i -g @eqworks/commit-watch
 % # or
@@ -16,25 +24,13 @@ Then:
 % commit-watch --help
 ```
 
-If you have `npx` available, you can directly use it without explicit installation:
+## Usage
 
-```shell
-% npx @eqworks/commit-watch --help
-```
-
-## Sample usage
-
-This CLI is designed to be used in any git repository to exit with code 1 (`process.exit(1)`) when there are any mismatches of the commit message (subject line only) convention.
-
-```
-category[/sub-category] - subject title
-```
-
-or in RegEx as `/(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/`
+This CLI is designed to work in any git repository to exit with code 1 (`process.exit(1)`) when there are any mismatches of the commit message (subject line only) against the convention `category[/sub-category] - subject title` or in RegEx as `/(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/`:
 
 ```shell
 % commit-watch -b origin/master -v
-⚠ 6/9 do not match RegExp/(?<cat>\S+?)(\/(?<t2>\S+))? - (?<title>.*)/
+⚠ 6/9 do not match pattern "category[/sub-category] - subject title"
 
 ✖ define APIError
 ✖ fix /readme to reflect changes in selectUser
@@ -54,4 +50,8 @@ and the exit code:
 1
 ```
 
-To use it in an automated/CI environment such as GitHub Actions, check out the `dogfood` job in [this workflow](.github/workflows/main.yml).
+To use it in an automated/CI environment such as GitHub Actions, check out the `dogfood` job in [this workflow](.github/workflows/main.yml), essentially by pinning down the `--base` and `--head` git refs (in this case, through the given `${{ github }}` context):
+
+```
+commit-watch -b ${{ github.event.pull_request.base.sha }} -h ${{ github.event.pull_request.head.sha }} -v
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/commit-watch",
-  "version": "0.2.0-alpha.0",
+  "version": "0.2.0",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/commit-watch",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "source": "index.js",


### PR DESCRIPTION
The default base git ref is auto detected (following the convention of either `main` or `master`), and displayed in help too:

```shell
(commit-watch) % commit-watch --help
Options:
      --help     Show help                                             [boolean]
      --version  Show version number                                   [boolean]
  -v, --verbose  verbose/debug flag                   [boolean] [default: false]
  -b, --base     base git ref to compare with the head ref
                                               [string] [default: "origin/main"]
  -h, --head     head git ref to compare with the base ref
                                                      [string] [default: "HEAD"]
      --fetch    perform a git fetch before commit-watch
                                                      [boolean] [default: false]
```